### PR TITLE
Update Gradle Plugin for Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.2.0-beta3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
If you're using AS 2.2 Beta 3, this change is necessary.

- Update Gradle Plugin for Android from 2.2.0 Beta 2 to Beta 3